### PR TITLE
update for nodepool support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Follow these steps to provision a custom node -
 
     e. `SUBSCRIPTION_ID` is the `id` of subscription for which you want to add this node.
 
-    f. `NODE_INIT_SCRIPT` is the name of script file. It contains the name of OS and docker version. You can check all the supported OS and docker versions [here](https://github.com/Shippable/node/tree/master/scripts). An example value is `Ubuntu_16.04_Docker_1.13.sh`.
-3. Install node packages: `sudo npm install`
+    f. `NODE_INIT_SCRIPT` is the name of script file that will be downloaded to use for initializing your new node.  The name is combination of architecture, operating system, and Docker version. You can check all the supported versions [here](https://github.com/Shippable/node/tree/master/initScripts). This argument should be the script path from inside the `initScripts` directory.  An example value is `x86_64/Ubuntu_16.04/Docker_1.13.sh`.
+
+    g. `CLUSTER_ID` is an integer that represents the unique ID of the node pool to which you are adding the node.  You can get this ID from the URL when visiting your subscription node pool page.  This parameter is optional.  If left as null, the script will automatically fetch the default CLUSTER_ID for your subscription.
+3. Install node packages: `npm install`
 4. To provision custom node run ` node createCustomNode.js`. After this completes, node initialization script will be saved in `initScript.sh`. You can run it on your machine to use it as a Shippable node.
 

--- a/ShippableAdapter.js
+++ b/ShippableAdapter.js
@@ -109,6 +109,12 @@ function _parseResponse(bag, next) {
   return next();
 }
 
+ShippableAdapter.prototype.getSubscriptionById =
+  function (id, callback) {
+    var url = '/subscriptions/' + id;
+    this.get(url, callback);
+  };
+
 ShippableAdapter.prototype.getNodeInitScript =
   function (clusterNodeId, callback) {
     var url = '/clusterNodes/' + clusterNodeId + '/initScript';

--- a/config.json
+++ b/config.json
@@ -1,10 +1,11 @@
 {
-  "SHIPPABLE_API_TOKEN": "specify-your-api-token-here",
+  "SHIPPABLE_API_TOKEN": "your Shippable API token",
   "FRIENDLY_NAME": "my-node",
   "IS_SHIPPABLE_INITIALIZED": false,
-  "NODE_LOCATION": "127.0.0.1",
+  "NODE_LOCATION": "your node IP address",
   "NODE_TYPE_CODE": 7000,
   "SSH_PORT": 22,
-  "NODE_INIT_SCRIPT": "Ubuntu_16.04_Docker_1.13.sh",
-  "SUBSCRIPTION_ID": "specify-your-subscription-id-here"
+  "NODE_INIT_SCRIPT": "x86_64/Ubuntu_16.04/Docker_1.13.sh",
+  "SUBSCRIPTION_ID": "your Shippable subscription ID",
+  "CLUSTER_ID": null
 }


### PR DESCRIPTION
fixes #2

update the script to allow the user to specify which node pool the node should be added to.  If no pool is specified, the default pool for the subscription will be automatically selected.

updates readme to include description of CLUSTER_ID, as well as linking to the correct directory for init scripts.